### PR TITLE
feat: add `zerocopy` integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ repository = "https://github.com/LiosK/fstr-rs"
 default = ["std"]
 std = []
 serde = ["dep:serde"]
+zerocopy = ["dep:zerocopy"]
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
+zerocopy = { version = "0.7", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ assert_eq!(buffer.slice_to_terminator('\0'), "haste makes waste");
 
 - `std` (optional; enabled by default) enables the integration with `std`. Disable default
   features to operate this crate under `no_std` environments.
-- `serde` (optional) enables the serialization and deserialization of `FStr`through `serde`.
+- `serde` (optional) enables the serialization and deserialization of `FStr` through `serde`.
+- `zerocopy` (optional) enables the integration with `zerocopy`.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ use std::{borrow, fmt, hash, mem, ops, str};
 ///
 /// See [the crate-level documentation](crate) for details.
 #[derive(Copy, Clone, Eq, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(zerocopy::AsBytes, zerocopy::FromBytes, zerocopy::FromZeroes)
+)]
 #[repr(transparent)]
 pub struct FStr<const N: usize> {
     inner: [u8; N],


### PR DESCRIPTION
https://github.com/google/zerocopy

This makes `fstr` useful when writing network protocol parsers.